### PR TITLE
Add login to mobile app

### DIFF
--- a/app/view/LoginWebView.js
+++ b/app/view/LoginWebView.js
@@ -1,0 +1,33 @@
+import React, {Component} from 'react';
+import {WebView} from 'react-native';
+
+class LoginWebView extends Component {
+
+  render() {
+    return (
+      <WebView
+        source={{uri: 'https://www.breakerapp.com/application/startAuthForMobileApp'}}
+        onShouldStartLoadWithRequest={this.onShouldStartLoadWithRequest.bind(this)}
+        style={{marginTop: 20}}
+      />
+    );
+  }
+
+  onShouldStartLoadWithRequest(event) {
+    // Implement any custom loading logic here, don't forget to return!
+    console.log('Loading: '+event.url);
+    if (event.url.startsWith('breaker://auth')) {
+      var authCode = event.url.substring(event.url.lastIndexOf('/') + 1);
+      console.log('Received breaker auth code: ' + authCode);
+      this.props.onAuthCode(authCode);
+      return true;
+    }
+    return true;
+  }
+}
+
+LoginWebView.propTypes = {
+  onAuthCode: React.PropTypes.func.isRequired
+};
+
+export default LoginWebView;

--- a/app/web/socket.js
+++ b/app/web/socket.js
@@ -8,8 +8,8 @@ let lastPingTime = null;
 
 import RNReconnectingWebSocket from '../rn-reconnecting-websocket.js'
 
-function socketConnect () {
-  let websocketUrl = Config.websocket_url.replace('ws:', 'wss:') ;
+function socketConnect (authCode) {
+  let websocketUrl = Config.websocket_url.replace('ws:', 'wss:') + authCode;
   const socketOptions = {
     debug: false,
     reconnectInterval: 5000,
@@ -19,9 +19,9 @@ function socketConnect () {
   socket = new RNReconnectingWebSocket(websocketUrl, null, socketOptions);
 }
 
-function init(store) {
+function init(store, authCode) {
 
-  socketConnect();
+  socketConnect(authCode);
 
   let pingTimeout = null;
 
@@ -113,9 +113,9 @@ function init(store) {
   };
 }
 
-export default function (store) {
+export default function (store, authCode) {
   if (!socket) {
-    init(store);
+    init(store, authCode);
   }
 
   return socket;

--- a/app/web/socket.js
+++ b/app/web/socket.js
@@ -9,7 +9,7 @@ let lastPingTime = null;
 import RNReconnectingWebSocket from '../rn-reconnecting-websocket.js'
 
 function socketConnect () {
-  let websocketUrl = Config.websocket_url.replace('ws:', 'wss:');
+  let websocketUrl = Config.websocket_url.replace('ws:', 'wss:') ;
   const socketOptions = {
     debug: false,
     reconnectInterval: 5000,

--- a/app/window-imitate.js
+++ b/app/window-imitate.js
@@ -7,7 +7,7 @@ const window = {
 	__USER_GUEST__: true,
 	__USER_ADMIN__: false,
 
-	__WEBSOCKET_URL__: 'wss://www.breakerapp.com/websocket/room/socket?test=true',
+	__WEBSOCKET_URL__: 'wss://www.breakerapp.com/websocket/room/socket?accessCode=',
 
 	__ROOM_NAME__: 'breakerapp',
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,11 +1,12 @@
 import {
-		AppRegistry, Text, View, Dimensions
+		AppRegistry, Text, View, Dimensions, AsyncStorage
 		} from 'react-native';
 
 import React, { Component } from 'react';
 
 import Root from './app/view/Root.js';
 import window from './app/window-imitate';
+import LoginWebView from './app/view/LoginWebView.js';
 
 import createRootStore from './app/web/redux/store/store';
 import { Provider } from 'react-redux';
@@ -20,11 +21,6 @@ import initSocket from './app/web/socket.js';
 
 import {Promise} from 'es6-promise'
 import initialStateJSON from './app/initialState.json';
-const fetchInitialState = () => {
-	//return fetch('https://www.breakerapp.com/application/initialState?test=true').then((res) => res.json())
-	return new Promise((resolve) => resolve(initialStateJSON))
-};
-
 // we need this platform detection in shared redux code
 global.__isReactNative = true;
 
@@ -33,28 +29,60 @@ class breaker_mobile extends Component {
 		super(props);
 
 		this.state = {
-			initialStateFetched: false
+			initialStateFetched: false,
+			loggedIn: false,
+			authCode: ''
 		};
 
-		// todo: why top level initialized two times?
-		fetchInitialState()
-				.then((__INITIAL_STATE__) => {
-					console.log(555);
-					const reachedInitialState = _assign(__INITIAL_STATE__, {
-						//currentRoom: 'zikapp'
-						currentRoom: 'zikapp'
-					});
+		var component = this;
 
-					const store = createRootStore(reachedInitialState);
+		var authCodeResponse = function(value) {
+			console.log("authCode stored value: "+value);
+			if (value) {
+				this.setState({
+					authCode: value,
+					loggedIn: true
+				});
 
-					initSocket(store);
+				this.setupAppFromInitialState();
+			}
+		};
+		authCodeResponse = authCodeResponse.bind(this);
 
-					this.setState({
-						initialStateFetched: true,
-						store: store
-					})
-				})
+		AsyncStorage.getItem('authcode').then(authCodeResponse);
 	}
+
+	fetchInitialState() {
+		return fetch('https://www.breakerapp.com/application/initialState', {
+			headers: {
+				'X-BreakerAccessCode': this.state.authCode
+			}
+		}).then((res) => {
+			console.log("Got server response.");
+			return res.json();
+		});
+		// return new Promise((resolve) => resolve(initialStateJSON))
+	};
+
+	setupAppFromInitialState() {
+      this.fetchInitialState()
+        .then((__INITIAL_STATE__) => {
+          console.log(555);
+          const reachedInitialState = _assign(__INITIAL_STATE__, {
+            //currentRoom: 'zikapp'
+            currentRoom: 'breakerapp'
+          });
+
+          const store = createRootStore(reachedInitialState);
+
+          initSocket(store);
+
+          this.setState({
+            initialStateFetched: true,
+            store: store
+          })
+        });
+    }
 
 	renderLoader() {
 		const {height, width} = Dimensions.get('window');
@@ -77,10 +105,27 @@ class breaker_mobile extends Component {
 		</View>
 	}
 
-	render() {
-		const {initialStateFetched, store} = this.state;
+	authCodeReceived(authCode) {
+		console.log("Authcode received in main obj: " + authCode);
 
-		if (initialStateFetched) {
+		AsyncStorage.setItem('authcode', authCode)
+      .then(() => {
+        this.setState({
+          authCode: authCode,
+          loggedIn: true
+        });
+        this.setupAppFromInitialState();
+      });
+	}
+
+	render() {
+		const {initialStateFetched, loggedIn, store} = this.state;
+
+		if (!loggedIn) {
+			return <LoginWebView
+				onAuthCode={this.authCodeReceived.bind(this)}
+			/>;
+		} else if (initialStateFetched) {
 			return <Provider store={store}>
 				<Root />
 			</Provider>;

--- a/index.ios.js
+++ b/index.ios.js
@@ -58,8 +58,12 @@ class breaker_mobile extends Component {
 				'X-BreakerAccessCode': this.state.authCode
 			}
 		}).then((res) => {
-			console.log("Got server response.");
-			return res.json();
+			if (res.ok) {
+				console.log("Got valid server response.");
+				return res.json();
+			} else {
+				return null;
+			}
 		});
 		// return new Promise((resolve) => resolve(initialStateJSON))
 	};
@@ -67,7 +71,17 @@ class breaker_mobile extends Component {
 	setupAppFromInitialState() {
       this.fetchInitialState()
         .then((__INITIAL_STATE__) => {
-          console.log(555);
+					if (__INITIAL_STATE__ == null) {
+						console.log("Error getting initial state, logging out.");
+						AsyncStorage.removeItem('authcode');
+						this.setState({
+							loggedIn: false,
+							authCode: ''
+						});
+
+						return;
+					}
+          console.log('Processing initial state...');
           const reachedInitialState = _assign(__INITIAL_STATE__, {
             //currentRoom: 'zikapp'
             currentRoom: 'breakerapp'
@@ -75,7 +89,7 @@ class breaker_mobile extends Component {
 
           const store = createRootStore(reachedInitialState);
 
-          initSocket(store);
+          initSocket(store, this.state.authCode);
 
           this.setState({
             initialStateFetched: true,


### PR DESCRIPTION
Here is the fully working login. You don't have to merge this PR if there are problems with how I've done some of the RN stuff but the basics are here. Here's the overview:
1. If no authcode is in async storage, then show a webview pointing to the server login page.
2. Watch what URLs that webview loads and if we see an authentication success URL, then save the access code returned.
3. Store the access code in async storage.
4. Pass the access code as a header to any URL requests to identify yourself
5. Pass it as a parameter to the websocket URL because websockets are a busted half standard that doesn't support headers :/
